### PR TITLE
Reflects changes in routing Error types

### DIFF
--- a/src/pmid_manager/mod.rs
+++ b/src/pmid_manager/mod.rs
@@ -20,6 +20,7 @@
 mod database;
 use routing;
 use routing::NameType;
+use routing::error::{ResponseError, InterfaceError};
 use routing::types::DestinationAddress;
 pub use self::database::PmidManagerAccountWrapper;
 
@@ -32,13 +33,13 @@ impl PmidManager {
     PmidManager { db_: database::PmidManagerDatabase::new() }
   }
 
-  pub fn handle_put(&mut self, dest_address: &DestinationAddress, data : &Vec<u8>) ->Result<routing::Action, routing::RoutingError> {
+  pub fn handle_put(&mut self, dest_address: &DestinationAddress, data : &Vec<u8>) ->Result<routing::Action, InterfaceError> {
     if self.db_.put_data(&dest_address.dest, data.len() as u64) {
       let mut destinations : Vec<NameType> = Vec::new();
       destinations.push(dest_address.dest.clone());
       Ok(routing::Action::SendOn(destinations))
     } else {
-      Err(routing::RoutingError::InvalidRequest)
+      Err(From::from(ResponseError::InvalidRequest))
     }
   }
 


### PR DESCRIPTION
Should be merged after [this PR](https://github.com/dirvine/routing/pull/232/files) is merged. Note, some of the code could be simplified if we had the `fail!` macro mentioned [here](http://lucumr.pocoo.org/2014/11/6/error-handling-in-rust/) (it's not in the standard yet). Then we could write e.g. `fail!(ResponseError::NoData)` instead of `return Err(From::from(ResponseError::NoData))`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/dirvine/maidsafe_vault/64)
<!-- Reviewable:end -->
